### PR TITLE
Add timeout to fetch calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resonance-run/resonance-node",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/google-analytics/index.ts
+++ b/src/google-analytics/index.ts
@@ -16,43 +16,47 @@ export const triggerGAImpressionEvent = async ({
   gaClientId: string;
 }) => {
   try {
-    await fetch(
-      `https://www.google-analytics.com/mp/collect?measurement_id=${gaTrackingId}&api_secret=${gaAPISecret}`,
-      {
-        method: 'POST',
-        body: JSON.stringify({
-          client_id: gaClientId,
-          events: [
-            {
-              name: IMPRESSION_EVENT_NAME,
-              params: {
-                exp_variant_string: `RESAMP-${customization.id}-${customization.variation.id}`,
-                customization_id: customization.id,
-                variation_id: customization.variation.id,
-                user_id: userId,
+    await Promise.all([
+      fetch(
+        `https://www.google-analytics.com/mp/collect?measurement_id=${gaTrackingId}&api_secret=${gaAPISecret}`,
+        {
+          signal: AbortSignal.timeout(1000),
+          method: 'POST',
+          body: JSON.stringify({
+            client_id: gaClientId,
+            events: [
+              {
+                name: IMPRESSION_EVENT_NAME,
+                params: {
+                  exp_variant_string: `RESAMP-${customization.id}-${customization.variation.id}`,
+                  customization_id: customization.id,
+                  variation_id: customization.variation.id,
+                  user_id: userId,
+                },
               },
-            },
-          ],
-        }),
-      },
-    );
-    await fetch(
-      `https://www.google-analytics.com/mp/collect?measurement_id=${gaTrackingId}&api_secret=${gaAPISecret}`,
-      {
-        method: 'POST',
-        body: JSON.stringify({
-          client_id: gaClientId,
-          events: [
-            {
-              name: EXPERIENCE_IMPRESSION,
-              params: {
-                exp_variant_string: `RESAMP-${customization.id}-${customization.variation.id}`,
+            ],
+          }),
+        },
+      ),
+      fetch(
+        `https://www.google-analytics.com/mp/collect?measurement_id=${gaTrackingId}&api_secret=${gaAPISecret}`,
+        {
+          signal: AbortSignal.timeout(1000),
+          method: 'POST',
+          body: JSON.stringify({
+            client_id: gaClientId,
+            events: [
+              {
+                name: EXPERIENCE_IMPRESSION,
+                params: {
+                  exp_variant_string: `RESAMP-${customization.id}-${customization.variation.id}`,
+                },
               },
-            },
-          ],
-        }),
-      },
-    );
+            ],
+          }),
+        },
+      ),
+    ]);
     return 'success';
   } catch (error) {
     console.error('Error emitting GA Tracking event', error);

--- a/src/loadCustomizations.test.ts
+++ b/src/loadCustomizations.test.ts
@@ -47,16 +47,21 @@ describe('loadCustomizations', () => {
     });
     const expectedUrl = `https://resonance.example.com/customizations`;
     expect(fetch).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(expectedUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+
+    // @ts-expect-error fetch is actually a mock function
+    const mockCall = fetch.mock.calls[0];
+    expect(mockCall[0]).toEqual(expectedUrl);
+    expect(mockCall[1].headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(mockCall[1].body).toEqual(
+      JSON.stringify({
         userData,
         customizationType: 'resonance-copy',
       }),
-    });
+    );
+    const mockSignal = mockCall[1].signal;
+    expect(mockSignal).toBeInstanceOf(AbortSignal);
   });
 
   test('loadCustomizations makes call with preview data', async () => {
@@ -78,17 +83,22 @@ describe('loadCustomizations', () => {
     });
     const expectedUrl = `https://resonance.example.com/customizations`;
     expect(fetch).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(expectedUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+
+    // @ts-expect-error fetch is actually a mock function
+    const mockCall = fetch.mock.calls[0];
+    expect(mockCall[0]).toEqual(expectedUrl);
+    expect(mockCall[1].headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(mockCall[1].body).toEqual(
+      JSON.stringify({
         userData,
         customizationType: 'resonance-copy',
         previewOverrides: cookie.replace('resonance.preview=', ''),
       }),
-    });
+    );
+    const mockSignal = mockCall[1].signal;
+    expect(mockSignal).toBeInstanceOf(AbortSignal);
   });
 
   test('loadCustomizations makes call with preview data (browser)', async () => {
@@ -110,17 +120,22 @@ describe('loadCustomizations', () => {
     });
     const expectedUrl = `https://resonance.example.com/customizations`;
     expect(fetch).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(expectedUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+
+    // @ts-expect-error fetch is actually a mock function
+    const mockCall = fetch.mock.calls[0];
+    expect(mockCall[0]).toEqual(expectedUrl);
+    expect(mockCall[1].headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(mockCall[1].body).toEqual(
+      JSON.stringify({
         userData,
         customizationType: 'resonance-copy',
         previewOverrides: encodeURIComponent(overrideData),
       }),
-    });
+    );
+    const mockSignal = mockCall[1].signal;
+    expect(mockSignal).toBeInstanceOf(AbortSignal);
   });
 
   test('it returns the result of the fetch', async () => {
@@ -332,17 +347,22 @@ describe('loadCustomization', () => {
     });
     const expectedUrl = `https://resonance.example.com/customizations`;
     expect(fetch).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(expectedUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+
+    // @ts-expect-error fetch is actually a mock function
+    const mockCall = fetch.mock.calls[0];
+    expect(mockCall[0]).toEqual(expectedUrl);
+    expect(mockCall[1].headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(mockCall[1].body).toEqual(
+      JSON.stringify({
         userData,
         customizationType: 'resonance-copy',
         surfaceId: 'surfaceOne',
       }),
-    });
+    );
+    const mockSignal = mockCall[1].signal;
+    expect(mockSignal).toBeInstanceOf(AbortSignal);
   });
 
   test('loadCustomization makes call with preview data', async () => {
@@ -365,18 +385,23 @@ describe('loadCustomization', () => {
     });
     const expectedUrl = `https://resonance.example.com/customizations`;
     expect(fetch).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(expectedUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+
+    // @ts-expect-error fetch is actually a mock function
+    const mockCall = fetch.mock.calls[0];
+    expect(mockCall[0]).toEqual(expectedUrl);
+    expect(mockCall[1].headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(mockCall[1].body).toEqual(
+      JSON.stringify({
         userData,
         customizationType: 'resonance-copy',
         surfaceId: 'surfaceOne',
         previewOverrides: cookie.replace('resonance.preview=', ''),
       }),
-    });
+    );
+    const mockSignal = mockCall[1].signal;
+    expect(mockSignal).toBeInstanceOf(AbortSignal);
   });
 
   test('loadCustomization makes call with preview data (browser)', async () => {
@@ -399,19 +424,25 @@ describe('loadCustomization', () => {
     });
     const expectedUrl = `https://resonance.example.com/customizations`;
     expect(fetch).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(expectedUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
+
+    // @ts-expect-error fetch is actually a mock function
+    const mockCall = fetch.mock.calls[0];
+    expect(mockCall[0]).toEqual(expectedUrl);
+    expect(mockCall[1].headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(mockCall[1].body).toEqual(
+      JSON.stringify({
         userData,
         customizationType: 'resonance-copy',
         surfaceId: 'surfaceOne',
         previewOverrides: encodeURIComponent(overrideData),
       }),
-    });
+    );
+    const mockSignal = mockCall[1].signal;
+    expect(mockSignal).toBeInstanceOf(AbortSignal);
   });
+
   test('Returns a single customization', async () => {
     const request = new Request('https://resonance.example.com');
     const customization = await loadCustomization({

--- a/src/loadCustomizations.ts
+++ b/src/loadCustomizations.ts
@@ -128,6 +128,7 @@ const fetchCustomizations = async <K>({
   };
   const fullUrl = `${baseUrl}/customizations`;
   const res = await fetch(fullUrl, {
+    signal: AbortSignal.timeout(500),
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
If the service is down, abort quickly instead of causing the page to hang.